### PR TITLE
fix: fix destruction error when api fail

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,7 +12,7 @@ export default async function Page() {
   const totalBlocks = await fetchTotalBlocks();
   const blocks = await fetchBlocks({ perPage: 10 });
   const { transaction_count, unique_from_address_count } =
-    await fetchTotalTransactions();
+    (await fetchTotalTransactions()) || {};
   const { transactions } = await fetchTransactions({ perPage: 10 });
   const addressToName = await getAddressToName(
     flatten(transactions.map((txn) => [txn.from, txn.to_or_contract_address]))


### PR DESCRIPTION
There should be a destruction error when the api calling `await fetchTotalTransactions()` fail. It's better to use a default `{}` when destructing.

<img width="962" alt="Screenshot 2024-02-06 at 13 52 49" src="https://github.com/0xFacet/facet-scan/assets/19762038/fe3504cf-7dc2-4769-af66-51eb3a03dc69">
